### PR TITLE
RMET-3428 ::: fix: Don't trigger BROWSER_FINISHED when hiding app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>0.0.27</version>
+    <version>0.0.28</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>0.0.26</version>
+    <version>0.0.27</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
@@ -11,7 +11,9 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABCustomTabsControllerActivity
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
@@ -30,6 +32,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         context: Context,
         packageName: String,
         lifecycleScope: CoroutineScope,
+        flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     ) {
         CustomTabsClient.bindCustomTabsService(
@@ -39,7 +42,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
                 override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
                     client.warmup(0L)
                     customTabsSessionCallback(
-                        client.newSession(CustomTabsCallbackImpl(browserId, lifecycleScope))
+                        client.newSession(CustomTabsCallbackImpl(browserId, lifecycleScope, flowHelper))
                     )
                 }
 
@@ -52,13 +55,43 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
 
     private inner class CustomTabsCallbackImpl(
         private val browserId: String,
-        private val lifecycleScope: CoroutineScope
+        private val lifecycleScope: CoroutineScope,
+        flowHelper: OSIABFlowHelperInterface,
     ) : CustomTabsCallback() {
+
+        private var isCustomTabsActivityOnTop = false
+        init {
+            var browserEventsJob: Job? = null
+
+            browserEventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
+                if(event is OSIABEvents.OSIABCustomTabsEvent) {
+                    when (event.action) {
+                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_RESUMED -> {
+                            isCustomTabsActivityOnTop = true
+                        }
+                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_PAUSED -> {
+                            isCustomTabsActivityOnTop = false
+                        }
+                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED -> {
+                            browserEventsJob?.cancel()
+                        }
+                    }
+                }
+            }
+        }
         override fun onNavigationEvent(navigationEvent: Int, extras: Bundle?) {
             super.onNavigationEvent(navigationEvent, extras)
             val browserEvent = when (navigationEvent) {
                 NAVIGATION_FINISHED -> OSIABEvents.BrowserPageLoaded(browserId)
-                TAB_HIDDEN -> OSIABEvents.BrowserFinished(browserId)
+                TAB_HIDDEN -> {
+                    if(isCustomTabsActivityOnTop) {
+                        OSIABEvents.BrowserFinished(browserId)
+                    }
+                    else {
+                        // App not open but custom tabs is hidden (home button, recent apps, etc.)
+                        return
+                    }
+                }
                 else -> return
             }
             lifecycleScope.launch {
@@ -71,6 +104,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         browserId: String,
         context: Context,
         lifecycleScope: CoroutineScope,
+        flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     ) {
         val packageName = getDefaultCustomTabsPackageName(context)
@@ -80,6 +114,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
                 context,
                 it,
                 lifecycleScope,
+                flowHelper,
                 customTabsSessionCallback
             )
         } ?: customTabsSessionCallback(null)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
@@ -66,13 +66,13 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
             browserEventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
                 if(event is OSIABEvents.OSIABCustomTabsEvent) {
                     when (event.action) {
-                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_RESUMED -> {
+                        OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_RESUMED -> {
                             isCustomTabsActivityOnTop = true
                         }
-                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_PAUSED -> {
+                        OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_PAUSED -> {
                             isCustomTabsActivityOnTop = false
                         }
-                        OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED -> {
+                        OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_DESTROYED -> {
                             browserEventsJob?.cancel()
                         }
                     }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelperInterface.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelperInterface.kt
@@ -11,12 +11,14 @@ interface OSIABCustomTabsSessionHelperInterface {
      * @param browserId Identifier for the browser instance to emit events to
      * @param context Context to use when initializing the CustomTabsSession
      * @param lifecycleScope Coroutine scope to use to post browser events
+     * @param flowHelper Flow helper to listen to browser events
      * @param customTabsSessionCallback Callback to send the session instance (null if failed)
      */
     suspend fun generateNewCustomTabsSession(
         browserId: String,
         context: Context,
         lifecycleScope: CoroutineScope,
+        flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     )
 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -46,7 +46,17 @@ class OSIABCustomTabsRouterAdapter(
 
         closeEventJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
             if(event is OSIABEvents.OSIABCustomTabsEvent) {
-                completionHandler(event.action == OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED)
+                when(event.action) {
+                    OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_READY -> {
+                        completionHandler(false)
+                    }
+                    OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED -> {
+                        completionHandler(true)
+                    }
+                    else -> {
+                        return@listenToEvents
+                    }
+                }
                 closeEventJob?.cancel()
             }
         }
@@ -144,6 +154,7 @@ class OSIABCustomTabsRouterAdapter(
                     browserId,
                     context,
                     lifecycleScope,
+                    flowHelper,
                     customTabsSessionCallback = {
                         if(it == null) {
                             completionHandler(false)
@@ -176,7 +187,6 @@ class OSIABCustomTabsRouterAdapter(
                         }
                     }
                     else if(event.action == OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED) {
-                        onBrowserFinished()
                         eventsJob?.cancel()
                     }
                 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -178,7 +178,7 @@ class OSIABCustomTabsRouterAdapter(
         eventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
             when (event) {
                 is OSIABEvents.OSIABCustomTabsEvent -> {
-                    if(isFirstLoad && event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_READY) {
+                    if(event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_READY) {
                         try {
                             customTabsIntent.launchUrl(event.context, uri)
                             completionHandler(true)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -187,6 +187,7 @@ class OSIABCustomTabsRouterAdapter(
                         }
                     }
                     else if(event.action == OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED) {
+                        onBrowserFinished()
                         eventsJob?.cancel()
                     }
                 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -162,10 +162,9 @@ class OSIABCustomTabsRouterAdapter(
                         }
 
                         openCustomTabsIntent(it, uri, completionHandler)
+                        startCustomTabsControllerActivity()
                     }
                 )
-
-                startCustomTabsControllerActivity()
             } catch (e: Exception) {
                 completionHandler(false)
             }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -47,10 +47,10 @@ class OSIABCustomTabsRouterAdapter(
         closeEventJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
             if(event is OSIABEvents.OSIABCustomTabsEvent) {
                 when(event.action) {
-                    OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_READY -> {
+                    OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_READY -> {
                         completionHandler(false)
                     }
-                    OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED -> {
+                    OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_DESTROYED -> {
                         completionHandler(true)
                     }
                     else -> {
@@ -178,7 +178,7 @@ class OSIABCustomTabsRouterAdapter(
         eventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
             when (event) {
                 is OSIABEvents.OSIABCustomTabsEvent -> {
-                    if(isFirstLoad && event.action == OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_READY) {
+                    if(isFirstLoad && event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_READY) {
                         try {
                             customTabsIntent.launchUrl(event.context, uri)
                             completionHandler(true)
@@ -186,7 +186,7 @@ class OSIABCustomTabsRouterAdapter(
                             completionHandler(false)
                         }
                     }
-                    else if(event.action == OSIABCustomTabsControllerActivity.ACTION_CUSTOM_TABS_DESTROYED) {
+                    else if(event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_DESTROYED) {
                         onBrowserFinished()
                         eventsJob?.cancel()
                     }
@@ -198,6 +198,8 @@ class OSIABCustomTabsRouterAdapter(
                     }
                 }
                 is OSIABEvents.BrowserFinished -> {
+                    // Ensure that custom tabs controller activity is fully destroyed
+                    startCustomTabsControllerActivity(true)
                     onBrowserFinished()
                     eventsJob?.cancel()
                 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -56,6 +56,7 @@ class OSIABWebViewRouterAdapter(
             else {
                 activity.finish()
                 setWebViewActivity(null)
+                onBrowserFinished()
                 completionHandler(true)
             }
         }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -56,7 +56,6 @@ class OSIABWebViewRouterAdapter(
             else {
                 activity.finish()
                 setWebViewActivity(null)
-                onBrowserFinished()
                 completionHandler(true)
             }
         }
@@ -82,6 +81,7 @@ class OSIABWebViewRouterAdapter(
                             onBrowserPageLoaded()
                         }
                         is OSIABEvents.BrowserFinished -> {
+                            setWebViewActivity(null)
                             onBrowserFinished()
                             eventsJob?.cancel()
                         }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABCustomTabsControllerActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABCustomTabsControllerActivity.kt
@@ -19,6 +19,8 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
     companion object {
         const val ACTION_CUSTOM_TABS_DESTROYED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_DESTROYED"
         const val ACTION_CUSTOM_TABS_READY = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_READY"
+        const val ACTION_CUSTOM_TABS_PAUSED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_PAUSED"
+        const val ACTION_CUSTOM_TABS_RESUMED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_RESUMED"
         const val ACTION_CLOSE_CUSTOM_TABS = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CLOSE_CUSTOM_TABS"
     }
 
@@ -54,6 +56,36 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setup(intent)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)?.let { browserId ->
+            lifecycleScope.launch {
+                OSIABEvents.postEvent(
+                    OSIABCustomTabsEvent(
+                        browserId = browserId,
+                        action = ACTION_CUSTOM_TABS_PAUSED,
+                        context = this@OSIABCustomTabsControllerActivity
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)?.let { browserId ->
+            lifecycleScope.launch {
+                OSIABEvents.postEvent(
+                    OSIABCustomTabsEvent(
+                        browserId = browserId,
+                        action = ACTION_CUSTOM_TABS_RESUMED,
+                        context = this@OSIABCustomTabsControllerActivity
+                    )
+                )
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABCustomTabsControllerActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABCustomTabsControllerActivity.kt
@@ -17,10 +17,10 @@ import kotlinx.coroutines.launch
 
 class OSIABCustomTabsControllerActivity: AppCompatActivity() {
     companion object {
-        const val ACTION_CUSTOM_TABS_DESTROYED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_DESTROYED"
-        const val ACTION_CUSTOM_TABS_READY = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_READY"
-        const val ACTION_CUSTOM_TABS_PAUSED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_PAUSED"
-        const val ACTION_CUSTOM_TABS_RESUMED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CUSTOM_TABS_RESUMED"
+        const val EVENT_CUSTOM_TABS_DESTROYED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EVENT_CUSTOM_TABS_DESTROYED"
+        const val EVENT_CUSTOM_TABS_READY = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EVENT_CUSTOM_TABS_READY"
+        const val EVENT_CUSTOM_TABS_PAUSED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EVENT_CUSTOM_TABS_PAUSED"
+        const val EVENT_CUSTOM_TABS_RESUMED = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EVENT_CUSTOM_TABS_RESUMED"
         const val ACTION_CLOSE_CUSTOM_TABS = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CLOSE_CUSTOM_TABS"
     }
 
@@ -35,15 +35,7 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
         }
         else {
             intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)?.let { browserId ->
-                lifecycleScope.launch {
-                    OSIABEvents.postEvent(
-                        OSIABCustomTabsEvent(
-                            browserId = browserId,
-                            action = ACTION_CUSTOM_TABS_READY,
-                            context = this@OSIABCustomTabsControllerActivity
-                        )
-                    )
-                }
+                sendCustomTabsEvent(browserId, EVENT_CUSTOM_TABS_READY)
             }
         }
     }
@@ -61,30 +53,14 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)?.let { browserId ->
-            lifecycleScope.launch {
-                OSIABEvents.postEvent(
-                    OSIABCustomTabsEvent(
-                        browserId = browserId,
-                        action = ACTION_CUSTOM_TABS_PAUSED,
-                        context = this@OSIABCustomTabsControllerActivity
-                    )
-                )
-            }
+            sendCustomTabsEvent(browserId, EVENT_CUSTOM_TABS_PAUSED)
         }
     }
 
     override fun onResume() {
         super.onResume()
         intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)?.let { browserId ->
-            lifecycleScope.launch {
-                OSIABEvents.postEvent(
-                    OSIABCustomTabsEvent(
-                        browserId = browserId,
-                        action = ACTION_CUSTOM_TABS_RESUMED,
-                        context = this@OSIABCustomTabsControllerActivity
-                    )
-                )
-            }
+            sendCustomTabsEvent(browserId, EVENT_CUSTOM_TABS_RESUMED)
         }
     }
 
@@ -97,7 +73,7 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
                 OSIABEvents.postEvent(
                     OSIABCustomTabsEvent(
                         browserId = browserId,
-                        action = ACTION_CUSTOM_TABS_DESTROYED,
+                        action = EVENT_CUSTOM_TABS_DESTROYED,
                         context = this@OSIABCustomTabsControllerActivity
                     )
                 )
@@ -109,5 +85,17 @@ class OSIABCustomTabsControllerActivity: AppCompatActivity() {
             }
         }
         super.onDestroy()
+    }
+
+    private fun sendCustomTabsEvent(browserId: String, action: String) {
+        lifecycleScope.launch {
+            OSIABEvents.postEvent(
+                OSIABCustomTabsEvent(
+                    browserId = browserId,
+                    action = action,
+                    context = this@OSIABCustomTabsControllerActivity
+                )
+            )
+        }
     }
 }

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelperMock.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelperMock.kt
@@ -12,6 +12,7 @@ class OSIABCustomTabsSessionHelperMock: OSIABCustomTabsSessionHelperInterface {
         browserId: String,
         context: Context,
         lifecycleScope: CoroutineScope,
+        flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     ) {
         customTabsSessionCallback(CustomTabsSession.createMockSessionForTesting(ComponentName(context, componentName)))


### PR DESCRIPTION
## Description
Fixes issue with the `BROWSER_FINISHED` event improperly firing when switching apps
Fixes issue with keyboard not working when custom tabs is finished

## Context
* Previously for Custom Tabs, when the app was hidden via the home button, recent apps button, etc.. the `BROWSER_FINISHED` would improperly trigger due to the [`TAB_HIDDEN`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsCallback#TAB_HIDDEN()) navigation event.
* Previously for Custom Tabs, when the browser was finished, the soft keyboard would not work on the app due to the `CustomTabsControllerActivity` not being destroyed

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
