### PR TITLE
RMET-3560 OSInAppBrowserLib-Android - Correctly position elements in bottom toolbar when `leftToRight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- Fix position of elements in bottom toolbar when 'isLeftRight' is true in `OpenInWebView` (https://outsystemsrd.atlassian.net/browse/RMET-3560)
+
 ### Features
 - Add `Close` feature for WebView and System Browser (https://outsystemsrd.atlassian.net/browse/RMET-3428).
 - Add permissions requests and opening file chooser to `OpenInWebView` feature (https://outsystemsrd.atlassian.net/browse/RMET-3534).

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>0.0.28</version>
+    <version>0.0.29</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -514,12 +514,13 @@ class OSIABWebViewActivity : AppCompatActivity() {
                 0
             )
             set.applyTo(content)
+
         }
 
         if (!showNavigationButtons) {
             navigationView.removeView(nav)
         } else defineNavigationButtons(isLeftRight, content)
-
+        
         if (!showURL) navigationView.removeView(urlText)
         else defineURLView(url, showNavigationButtons, navigationView, toolbarPosition, isLeftRight)
 
@@ -542,16 +543,14 @@ class OSIABWebViewActivity : AppCompatActivity() {
         showNavigationButtons: Boolean,
         navigationView: ConstraintLayout,
         toolbarPosition: OSIABToolbarPosition,
-        isLeftRight: Boolean) {
+        isLeftRight: Boolean
+    ) {
         urlText.text = url
         if (!showNavigationButtons) {
             val set = ConstraintSet()
             set.clone(navigationView)
             set.connect(
-                urlText.id,
-                ConstraintSet.END,
-                ConstraintSet.PARENT_ID,
-                ConstraintSet.END
+                urlText.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END
             )
             if (toolbarPosition == OSIABToolbarPosition.TOP)
                 set.clear(urlText.id, ConstraintSet.START)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -514,40 +514,52 @@ class OSIABWebViewActivity : AppCompatActivity() {
                 0
             )
             set.applyTo(content)
-
         }
 
         if (!showNavigationButtons) {
             navigationView.removeView(nav)
         } else defineNavigationButtons(isLeftRight, content)
 
-
         if (!showURL) navigationView.removeView(urlText)
-        else {
-            urlText.text = url
-            if (!showNavigationButtons) {
-                val set = ConstraintSet()
-                set.clone(navigationView)
-                set.connect(
-                    urlText.id,
-                    ConstraintSet.END,
-                    ConstraintSet.PARENT_ID,
-                    ConstraintSet.END
-                )
-                if (toolbarPosition == OSIABToolbarPosition.TOP)
-                    set.clear(urlText.id, ConstraintSet.START)
-                set.applyTo(navigationView)
-
-                if (toolbarPosition == OSIABToolbarPosition.TOP) urlText.gravity = Gravity.START
-            } else if (toolbarPosition == OSIABToolbarPosition.BOTTOM)
-                urlText.gravity = if (isLeftRight) Gravity.END else Gravity.START
-        }
+        else defineURLView(url, showNavigationButtons, navigationView, toolbarPosition, isLeftRight)
 
         if (isLeftRight) {
             bottomToolbar.layoutDirection = View.LAYOUT_DIRECTION_RTL
             toolbar.layoutDirection = View.LAYOUT_DIRECTION_RTL
-
         }
+    }
+
+    /**
+     * Sets the URL content and position
+     * @param url String to set as the URL element text
+     * @param showNavigationButtons to use when determining the position of the URL text
+     * @param navigationView ConstraintLayout view representing the navigation view (nav buttons and URL)
+     * @param toolbarPosition the toolbar position on screen, to determine the position of the URL
+     * @param isLeftRight to use when determining the position of the URL text
+     */
+    private fun defineURLView(
+        url: String,
+        showNavigationButtons: Boolean,
+        navigationView: ConstraintLayout,
+        toolbarPosition: OSIABToolbarPosition,
+        isLeftRight: Boolean) {
+        urlText.text = url
+        if (!showNavigationButtons) {
+            val set = ConstraintSet()
+            set.clone(navigationView)
+            set.connect(
+                urlText.id,
+                ConstraintSet.END,
+                ConstraintSet.PARENT_ID,
+                ConstraintSet.END
+            )
+            if (toolbarPosition == OSIABToolbarPosition.TOP)
+                set.clear(urlText.id, ConstraintSet.START)
+            set.applyTo(navigationView)
+
+            if (toolbarPosition == OSIABToolbarPosition.TOP) urlText.gravity = Gravity.START
+        } else if (toolbarPosition == OSIABToolbarPosition.BOTTOM)
+            urlText.gravity = if (isLeftRight) Gravity.END else Gravity.START
     }
 
     /**

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -540,7 +540,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
                 if (toolbarPosition == OSIABToolbarPosition.TOP) urlText.gravity = Gravity.START
             } else if (toolbarPosition == OSIABToolbarPosition.BOTTOM)
-                urlText.gravity = Gravity.START
+                urlText.gravity = if (isLeftRight) Gravity.END else Gravity.START
         }
 
         if (isLeftRight) {

--- a/src/main/res/values-v28/styles.xml
+++ b/src/main/res/values-v28/styles.xml
@@ -8,5 +8,7 @@
         <item name="android:id">@id/close_button</item>
         <item name="android:backgroundTint">@android:color/transparent</item>
         <item name="android:background">@android:color/transparent</item>
+        <item name="android:paddingStart">8dp</item>
+        <item name="android:paddingEnd">8dp</item>
     </style>
 </resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -50,6 +50,8 @@
         <item name="android:textStyle">bold</item>
         <item name="android:backgroundTint">@android:color/transparent</item>
         <item name="android:background">@android:color/transparent</item>
+        <item name="android:paddingStart">8dp</item>
+        <item name="android:paddingEnd">8dp</item>
     </style>
 
     <!-- Custom Tabs Controller Activity -->


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Correctly positions URL text in toolbar when `leftToRight = true` and `ToolbarPosition = BOTTOM`
- Also sets the padding around the `Close` button to be the same as the one for the `Navigation Buttons`

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-3560

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 14 Pixel 7 device.

## Screenshots (if appropriate)

| ![image](https://github.com/user-attachments/assets/40fd24d7-cac6-4aea-91d6-bf3f18b8575e)  |  ![image](https://github.com/user-attachments/assets/6d913a62-9eae-4976-9b03-cb4b2bf1f5cd)  | ![image](https://github.com/user-attachments/assets/1d76638e-0d46-44bb-b5b8-3192563e63f1) | ![image](https://github.com/user-attachments/assets/f713c671-a557-4b25-9b5d-effb620728ee)
|---|---|---|---|



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
