### PR TITLE
RMET-3434 :: Remove `allowBackup` flag as this should not be setted by the pl…

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application
-        android:allowBackup="false"
         android:supportsRtl="true">
         <activity
             android:name=".views.OSIABWebViewActivity"


### PR DESCRIPTION
## Description
This PR removes `allowBackup` flag, as this should not be setted by the plugin

## Context
Capacitor apps have this flag defaulting to `true`. This flags needs to be consistent across all app dependencies/ibs. The plugin doesn't need to set this, so we just remove it.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Android build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=a8fc907a64db396e906187537a072d81219359d0&stg=dev

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
