### PR TITLE
RMET-3680 OSInAppBrowserLib-Android - Don't try to resolve activity before opening URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1
+
+### Fixes
+- Fix issue where some URLs weren't being open in Custom Tabs and the External Browser (https://outsystemsrd.atlassian.net/browse/RMET-3680)
+
 ## 1.0.0
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-dev</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>1.0.1-dev</version>
+    <version>1.0.1</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEngine.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEngine.kt
@@ -49,8 +49,3 @@ class OSIABEngine {
         return webViewRouter.handleOpen(url, completionHandler)
     }
 }
-
-fun Context.canOpenURL(uri: Uri): Boolean {
-    val intent = Intent(Intent.ACTION_VIEW, uri)
-    return intent.resolveActivity(packageManager) != null
-}

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.canOpenURL
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelper
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelperInterface
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABFlowHelperInterface
@@ -145,11 +144,6 @@ class OSIABCustomTabsRouterAdapter(
         lifecycleScope.launch {
             try {
                 val uri = Uri.parse(url)
-                if (!context.canOpenURL(uri)) {
-                    completionHandler(false)
-                    return@launch
-                }
-
                 customTabsSessionHelper.generateNewCustomTabsSession(
                     browserId,
                     context,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABExternalBrowserRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABExternalBrowserRouterAdapter.kt
@@ -5,16 +5,11 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Browser.EXTRA_APPLICATION_ID
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABRouter
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.canOpenURL
 
 class OSIABExternalBrowserRouterAdapter(private val context: Context) : OSIABRouter<Boolean> {
     override fun handleOpen(url: String, completionHandler: (Boolean) -> Unit) {
         try {
             val uri = Uri.parse(url)
-            if (!context.canOpenURL(uri)) {
-                completionHandler(false)
-                return
-            }
             val intent = Intent(Intent.ACTION_VIEW, uri)
             intent.putExtra(EXTRA_APPLICATION_ID, context.packageName)
             context.startActivity(intent)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR fixes an issue where some URLs aren't being open in Custom Tabs and the External Browser by removing the verification made with `canOpenUrl`.

- **Reasoning**:
    - `resolveActivity` can return `null` even if the URL can actually be opened. 
    - This means that some valid URLs won't be open in Custom Tabs or the External Browser.
    - To fix this behaviour, we can simply remove the verification made with `canOpenUrl`.
    - Even if something happens when trying to open the URL, that will be caught in the `catch` clauses, maintaining the current behaviour, as the error returned is the same.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3680

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in Android 15 (Pixel 7).

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=82ce90ebd3fcd5c99dbdc8f6915324d50410b70a

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
