### PR TITLE
RMET-3982 - Update workflow to publish library under `io.ionic.libs`

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -4,7 +4,7 @@ name: Publish Native Android Library
 on:
   workflow_dispatch:
   push:
-    branches: [ test-publish-android ]
+    branches: [test-publish-android]
 
 jobs:
   publish-android:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,10 +1,6 @@
 name: Publish Native Android Library
 
-#on: workflow_dispatch
-on:
-  workflow_dispatch:
-  push:
-    branches: [test-publish-android]
+on: workflow_dispatch
 
 jobs:
   publish-android:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -36,11 +36,4 @@ jobs:
           echo "local.properties file has been created successfully."
       - name: Run publish script
         working-directory: ./scripts
-        env:
-          ANDROID_OSSRH_USERNAME: ${{ secrets.ANDROID_OSSRH_USERNAME }}
-          ANDROID_OSSRH_PASSWORD: ${{ secrets.ANDROID_OSSRH_PASSWORD }}
-          ANDROID_SIGNING_KEY_ID: ${{ secrets.ANDROID_SIGNING_KEY_ID }}
-          ANDROID_SIGNING_PASSWORD: ${{ secrets.ANDROID_SIGNING_PASSWORD }}
-          ANDROID_SIGNING_KEY: ${{ secrets.ANDROID_SIGNING_KEY }}
-          ANDROID_SONATYPE_STAGING_PROFILE_ID: ${{ secrets.ANDROID_SONATYPE_STAGING_PROFILE_ID }}
         run: ./publish-android.sh

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,6 +1,10 @@
 name: Publish Native Android Library
 
-on: workflow_dispatch
+#on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches: [test-publish-android]
 
 jobs:
   publish-android:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -4,7 +4,7 @@ name: Publish Native Android Library
 on:
   workflow_dispatch:
   push:
-    branches: [test-publish-android]
+    branches: [ test-publish-android ]
 
 jobs:
   publish-android:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Update `publish-android` workflow to publish library under io.ionic.libs (https://outsystemsrd.atlassian.net/browse/RMET-3982)
+
 ## 1.2.1
 
 - Remove unnecessary permissions from AndroidManifest (https://outsystemsrd.atlassian.net/browse/RMET-3987)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
              http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.outsystems</groupId>
+    <groupId>io.ionic.libs</groupId>
     <artifactId>osinappbrowser-android</artifactId>
     <version>1.2.1</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
-    <artifactId>osinappbrowser-android</artifactId>
+    <artifactId>ioninappbrowser-android</artifactId>
     <version>1.2.1</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>1.2.1.1</version>
+    <version>1.2.1</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osinappbrowser-android</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.1.1</version>
 </project>

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -21,9 +21,9 @@ else
 
     printf %"s\n" "Attempting to build and publish version $THE_VERSION"
     # Publish a release to the Maven repo
-    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
     # Stage a version
-    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
 
     echo $RESULT
 

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -21,9 +21,9 @@ else
 
     printf %"s\n" "Attempting to build and publish version $THE_VERSION"
     # Publish a release to the Maven repo
-    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
     # Stage a version
-    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
 
     echo $RESULT
 

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -5,7 +5,7 @@ LOG_OUTPUT=./tmp/publish-android.txt
 THE_VERSION=`sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' ../pom.xml`
 
 # Get latest io.ionic:portals XML version info
-PUBLISHED_URL="https://repo1.maven.org/maven2/io/ionic/libs/osinappbrowser-android/maven-metadata.xml"
+PUBLISHED_URL="https://repo1.maven.org/maven2/io/ionic/libs/ioninappbrowser-android/maven-metadata.xml"
 PUBLISHED_DATA=$(curl -s $PUBLISHED_URL)
 PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $PUBLISHED_DATA)"
 
@@ -21,9 +21,9 @@ else
 
     printf %"s\n" "Attempting to build and publish version $THE_VERSION"
     # Publish a release to the Maven repo
-    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
     # Stage a version
-    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
 
     echo $RESULT
 

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -5,7 +5,7 @@ LOG_OUTPUT=./tmp/publish-android.txt
 THE_VERSION=`sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' ../pom.xml`
 
 # Get latest io.ionic:portals XML version info
-PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/osinappbrowser-android/maven-metadata.xml"
+PUBLISHED_URL="https://repo1.maven.org/maven2/io/ionic/libs/osinappbrowser-android/maven-metadata.xml"
 PUBLISHED_DATA=$(curl -s $PUBLISHED_URL)
 PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $PUBLISHED_DATA)"
 

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -20,8 +20,10 @@ else
     export SHOULD_PUBLISH=true
 
     printf %"s\n" "Attempting to build and publish version $THE_VERSION"
-    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
-    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    # Publish a release to the Maven repo
+    # "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
+    # Stage a version
+    "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
 
     echo $RESULT
 

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -18,7 +18,7 @@ artifacts {
     archives androidSourcesJar
 }
 
-group = 'com.capacitorjs'
+group = 'io.ionic.libs'
 version = LIB_VERSION
 
 afterEvaluate {
@@ -26,7 +26,7 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 // Coordinates
-                groupId 'com.capacitorjs'
+                groupId 'io.ionic.libs'
                 artifactId 'osinappbrowser-android'
                 version LIB_VERSION
 

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -27,7 +27,7 @@ afterEvaluate {
             release(MavenPublication) {
                 // Coordinates
                 groupId 'io.ionic.libs'
-                artifactId 'osinappbrowser-android'
+                artifactId 'ioninappbrowser-android'
                 version LIB_VERSION
 
                 // Two artifacts, the `aar` (or `jar`) and the sources
@@ -41,7 +41,7 @@ afterEvaluate {
 
                 // POM Data
                 pom {
-                    name = 'osinappbrowser-android'
+                    name = 'ioninappbrowser-android'
                     description = 'InAppBrowser Android Lib'
                     url = 'https://github.com/OutSystems/OSInAppBrowserLib-Android'
                     licenses {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates `publish-android` workflow and other configuration files so that library is published under `io.ionic.libs` instead of `com.capacitorjs`.
- Also updates library name on Maven to `ioninappbrowser-android`, following the same pattern we used for https://github.com/ionic-team/ion-android-geolocation
- Also removes unnecessary environment variables being passed into the `publish-android.sh` script

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3982

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested publishing stating version of library under `io.ionic.libs`, which was successful.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
