### PR TITLE
RMET-4121 ::: Add onBrowserPageNavigationCompleted event

### DIFF
--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
@@ -10,6 +10,7 @@ sealed class OSIABEvents {
 
     data class BrowserPageLoaded(override val browserId: String) : OSIABEvents()
     data class BrowserFinished(override val browserId: String) : OSIABEvents()
+    data class BrowserPageNavigationCompleted(override val browserId: String, val url: String?) : OSIABEvents()
 
     data class OSIABCustomTabsEvent(
         override val browserId: String,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
@@ -89,6 +89,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
                 }
             }
         }
+
         override fun onNavigationEvent(navigationEvent: Int, extras: Bundle?) {
             super.onNavigationEvent(navigationEvent, extras)
             val browserEvent = when (navigationEvent) {

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABBaseRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABBaseRouterAdapter.kt
@@ -13,7 +13,8 @@ abstract class OSIABBaseRouterAdapter<OptionsType : OSIABOptions, ReturnType>(
     protected val options: OptionsType,
     protected val flowHelper: OSIABFlowHelperInterface,
     protected val onBrowserPageLoaded: () -> Unit,
-    protected val onBrowserFinished: () -> Unit
+    protected val onBrowserFinished: () -> Unit,
+    protected val onBrowserPageNavigationCompleted: (String?) -> Unit
 ) : OSIABRouter<ReturnType>, OSIABClosable {
     abstract override fun close(completionHandler: (Boolean) -> Unit)
     abstract override fun handleOpen(url: String, completionHandler: (ReturnType) -> Unit)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -25,6 +25,7 @@ class OSIABCustomTabsRouterAdapter(
     flowHelper: OSIABFlowHelperInterface,
     onBrowserPageLoaded: () -> Unit,
     onBrowserFinished: () -> Unit,
+    onBrowserPageNavigationCompleted: (String?) -> Unit,
     private val customTabsSessionHelper: OSIABCustomTabsSessionHelperInterface = OSIABCustomTabsSessionHelper(),
 ) : OSIABBaseRouterAdapter<OSIABCustomTabsOptions, Boolean>(
     context = context,
@@ -32,7 +33,8 @@ class OSIABCustomTabsRouterAdapter(
     options = options,
     flowHelper = flowHelper,
     onBrowserPageLoaded = onBrowserPageLoaded,
-    onBrowserFinished = onBrowserFinished
+    onBrowserFinished = onBrowserFinished,
+    onBrowserPageNavigationCompleted = onBrowserPageNavigationCompleted
 ) {
 
     private val browserId = UUID.randomUUID().toString()
@@ -195,6 +197,9 @@ class OSIABCustomTabsRouterAdapter(
                     startCustomTabsControllerActivity(true)
                     onBrowserFinished()
                     eventsJob?.cancel()
+                }
+                is OSIABEvents.BrowserPageNavigationCompleted -> {
+                    onBrowserPageNavigationCompleted(event.url)
                 }
                 else -> {}
             }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -19,13 +19,15 @@ class OSIABWebViewRouterAdapter(
     flowHelper: OSIABFlowHelperInterface,
     onBrowserPageLoaded: () -> Unit,
     onBrowserFinished: () -> Unit,
+    onBrowserPageNavigationCompleted: (String?) -> Unit
 ) : OSIABBaseRouterAdapter<OSIABWebViewOptions, Boolean>(
     context = context,
     lifecycleScope = lifecycleScope,
     options = options,
     flowHelper = flowHelper,
     onBrowserPageLoaded = onBrowserPageLoaded,
-    onBrowserFinished = onBrowserFinished
+    onBrowserFinished = onBrowserFinished,
+    onBrowserPageNavigationCompleted = onBrowserPageNavigationCompleted
 ) {
     private val browserId = UUID.randomUUID().toString()
 
@@ -85,6 +87,9 @@ class OSIABWebViewRouterAdapter(
                             setWebViewActivity(null)
                             onBrowserFinished()
                             eventsJob?.cancel()
+                        }
+                        is OSIABEvents.BrowserPageNavigationCompleted -> {
+                            onBrowserPageNavigationCompleted(event.url)
                         }
                         else -> {}
                     }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -310,6 +310,8 @@ class OSIABWebViewActivity : AppCompatActivity() {
             if (isFirstLoad && !hasLoadError) {
                 sendWebViewEvent(OSIABEvents.BrowserPageLoaded(browserId))
                 isFirstLoad = false
+            } else if (!hasLoadError) {
+                sendWebViewEvent(OSIABEvents.BrowserPageNavigationCompleted(browserId, url))
             }
 
             // set back to false so that the next successful load


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
This PR adds the event onBrowserPageNavigationCompleted, which is triggered when the user navigates on the web view.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4121

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows the code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
