### PR TITLE
RMET-4121 :: Remove unused callback from CustomTabsRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Features
+
+- Add `onBrowserPageNavigationCompleted` event callback to WebView (https://outsystemsrd.atlassian.net/browse/RMET-4121)
+
+### Chores
+
 - Update `publish-android` workflow to publish library under io.ionic.libs (https://outsystemsrd.atlassian.net/browse/RMET-3982)
 
 ## 1.2.1

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABBaseRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABBaseRouterAdapter.kt
@@ -14,7 +14,6 @@ abstract class OSIABBaseRouterAdapter<OptionsType : OSIABOptions, ReturnType>(
     protected val flowHelper: OSIABFlowHelperInterface,
     protected val onBrowserPageLoaded: () -> Unit,
     protected val onBrowserFinished: () -> Unit,
-    protected val onBrowserPageNavigationCompleted: (String?) -> Unit
 ) : OSIABRouter<ReturnType>, OSIABClosable {
     abstract override fun close(completionHandler: (Boolean) -> Unit)
     abstract override fun handleOpen(url: String, completionHandler: (ReturnType) -> Unit)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -25,7 +25,6 @@ class OSIABCustomTabsRouterAdapter(
     flowHelper: OSIABFlowHelperInterface,
     onBrowserPageLoaded: () -> Unit,
     onBrowserFinished: () -> Unit,
-    onBrowserPageNavigationCompleted: (String?) -> Unit,
     private val customTabsSessionHelper: OSIABCustomTabsSessionHelperInterface = OSIABCustomTabsSessionHelper(),
 ) : OSIABBaseRouterAdapter<OSIABCustomTabsOptions, Boolean>(
     context = context,
@@ -33,8 +32,7 @@ class OSIABCustomTabsRouterAdapter(
     options = options,
     flowHelper = flowHelper,
     onBrowserPageLoaded = onBrowserPageLoaded,
-    onBrowserFinished = onBrowserFinished,
-    onBrowserPageNavigationCompleted = onBrowserPageNavigationCompleted
+    onBrowserFinished = onBrowserFinished
 ) {
 
     private val browserId = UUID.randomUUID().toString()
@@ -197,9 +195,6 @@ class OSIABCustomTabsRouterAdapter(
                     startCustomTabsControllerActivity(true)
                     onBrowserFinished()
                     eventsJob?.cancel()
-                }
-                is OSIABEvents.BrowserPageNavigationCompleted -> {
-                    onBrowserPageNavigationCompleted(event.url)
                 }
                 else -> {}
             }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -19,7 +19,7 @@ class OSIABWebViewRouterAdapter(
     flowHelper: OSIABFlowHelperInterface,
     onBrowserPageLoaded: () -> Unit,
     onBrowserFinished: () -> Unit,
-    onBrowserPageNavigationCompleted: (String?) -> Unit
+    private val onBrowserPageNavigationCompleted: (String?) -> Unit
 ) : OSIABBaseRouterAdapter<OSIABWebViewOptions, Boolean>(
     context = context,
     lifecycleScope = lifecycleScope,
@@ -27,7 +27,6 @@ class OSIABWebViewRouterAdapter(
     flowHelper = flowHelper,
     onBrowserPageLoaded = onBrowserPageLoaded,
     onBrowserFinished = onBrowserFinished,
-    onBrowserPageNavigationCompleted = onBrowserPageNavigationCompleted
 ) {
     private val browserId = UUID.randomUUID().toString()
 

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABCustomTabsRouterAdapterTests.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABCustomTabsRouterAdapterTests.kt
@@ -46,7 +46,6 @@ class OSIABCustomTabsRouterAdapterTests {
                 onBrowserPageLoaded = {},
                 onBrowserFinished = {},
                 customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = {}
             )
 
             sut.handleOpen(uri.toString()) { success ->
@@ -68,7 +67,6 @@ class OSIABCustomTabsRouterAdapterTests {
                 onBrowserPageLoaded = {},
                 onBrowserFinished = {},
                 customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = {}
             )
 
             sut.handleOpen("invalid_url") { success ->
@@ -92,7 +90,6 @@ class OSIABCustomTabsRouterAdapterTests {
                 onBrowserPageLoaded = {},
                 onBrowserFinished = {},
                 customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = {}
             )
 
             `when`(packageManager.resolveActivity(any(Intent::class.java), anyInt())).thenReturn(
@@ -125,7 +122,6 @@ class OSIABCustomTabsRouterAdapterTests {
                     fail()
                 },
                 customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = {}
             )
 
             sut.handleOpen(uri.toString()) { success ->
@@ -151,44 +147,10 @@ class OSIABCustomTabsRouterAdapterTests {
                     assertTrue(true) // onBrowserFinished was called
                 },
                 customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = {}
             )
 
             sut.handleOpen(uri.toString()) { success ->
                 assertTrue(success)
-            }
-        }
-    }
-
-    @Test
-    fun test_handleOpen_withValidURL_launchesCustomTab_when_browserPageNavigationCompleted_then_browserPageNavigationCompletedTriggered() {
-        runTest(StandardTestDispatcher()) {
-            var pageNavigationCalled = false
-            val context = mockContext(useValidURL = true, ableToOpenURL = true)
-            val flowHelperMock = OSIABFlowHelperMock().apply {
-                event = OSIABEvents.BrowserPageNavigationCompleted("", "https://test")
-            }
-            val sut = OSIABCustomTabsRouterAdapter(
-                context = context,
-                lifecycleScope = this,
-                flowHelper = flowHelperMock,
-                options = options,
-                onBrowserPageLoaded = {
-                    fail()
-                },
-                onBrowserFinished = {
-                    fail()
-                },
-                customTabsSessionHelper = OSIABCustomTabsSessionHelperMock(),
-                onBrowserPageNavigationCompleted = { url ->
-                    pageNavigationCalled = true
-                    assertEquals(url, "https://test")
-                }
-            )
-
-            sut.handleOpen(uri.toString()) { success ->
-                assertTrue(success)
-                assertTrue(pageNavigationCalled)
             }
         }
     }


### PR DESCRIPTION
References: https://outsystemsrd.atlassian.net/browse/RMET-4121

## Description

The `OSIABCustomTabsRouterAdapter` was able to receive an `onBrowserPageNavigationCompleted`, but it actually was never being called in practice - Because custom tabs do not support it.

This PR removes that event from the base class, and now it's only in the constructor of the router where it can actually be called - `OSIABWebViewRouterAdapter`

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-4121

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue) -> Would be a Breaking Change but because no version was released, it doesn't apply.
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Updated custom tabs unit tests to reflect the change

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
