### PR TITLE
RMET-4121 ::: Send onBrowserPageNavigationCompleted event when navigate to deeplink

### DIFF
--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -358,6 +358,12 @@ class OSIABWebViewActivity : AppCompatActivity() {
                     if (showURL) urlText.text = urlString
                     true
                 }
+                !urlString.startsWith("http:") && !urlString.startsWith("https:") && urlString.matches( Regex("^[A-Za-z0-9+.-]*://.*?\$")) -> {
+                    if (urlString.startsWith(packageName, ignoreCase = true)) {
+                        sendWebViewEvent(OSIABEvents.BrowserPageNavigationCompleted(browserId, urlString))
+                    }
+                    true
+                }
                 else -> false
             }
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds the event onBrowserPageNavigationCompleted, which is triggered when the user navigates on the web view.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4121

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows the code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
