### PR TITLE
RMET-4335 - Migrate back navigation to API supported for Android 16 and update lib to Android 16 (API 36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.1]
 
+### Features
+
+- Added support for predictive back navigation for Android 13+ (https://outsystemsrd.atlassian.net/browse/RMET-4335)
+
 ### Fixes
 
 - Migrate back button navigation on `OSIABWebViewActivity` to support apps targeting Android 16 (https://outsystemsrd.atlassian.net/browse/RMET-4335)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1]
+
+### Fixes
+
+- Migrate back button navigation on `OSIABWebViewActivity` to support apps targeting Android 16 (https://outsystemsrd.atlassian.net/browse/RMET-4335)
+
 ## [1.4.0]
 
 ### Features

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.9.24"
+    ext.kotlin_version = "1.9.25"
     ext.jacocoVersion = '0.8.7'
     repositories {
         google()
@@ -12,7 +12,7 @@ buildscript {
         if (System.getenv("SHOULD_PUBLISH") == "true") {
             classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         }
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
     }
@@ -41,11 +41,11 @@ apply plugin: "jacoco"
 
 android {
     namespace "com.outsystems.plugins.inappbrowser.osinappbrowserlib"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdk 26
-        targetSdk 35
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 29 18:08:54 CDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-dev</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>1.4.1-dev</version>
+    <version>1.4.1</version>
 </project>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.outsystems.plugins.inappbrowser.osinappbrowserlib">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -18,7 +19,9 @@
             android:exported="false"
             android:configChanges="orientation|screenSize|uiMode"
             android:label="OSIABWebViewActivity"
-            android:theme="@style/AppTheme.WebView" />
+            android:theme="@style/AppTheme.WebView"
+            android:enableOnBackInvokedCallback="true"
+            tools:targetApi="33" />
         <activity android:name=".views.OSIABCustomTabsControllerActivity"
             android:exported="false"
             android:theme="@style/Theme.Transparent"

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -24,6 +24,7 @@ import android.widget.Button
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -102,6 +103,20 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (options.hardwareBack && webView.canGoBack()) {
+                    hideErrorScreen()
+                    webView.goBack()
+                } else {
+                    sendWebViewEvent(OSIABEvents.BrowserFinished(browserId))
+                    webView.destroy()
+                    this.isEnabled = false // disable the callback to prevent it from being called again
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
 
         browserId = intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID) ?: ""
 
@@ -247,20 +262,6 @@ class OSIABWebViewActivity : AppCompatActivity() {
      */
     private fun customWebChromeClient(): WebChromeClient {
         return OSIABWebChromeClient()
-    }
-
-    /**
-     * Handle the back button press
-     */
-    override fun onBackPressed() {
-        if (options.hardwareBack && webView.canGoBack()) {
-            hideErrorScreen()
-            webView.goBack()
-        } else {
-            sendWebViewEvent(OSIABEvents.BrowserFinished(browserId))
-            webView.destroy()
-            onBackPressedDispatcher.onBackPressed()
-        }
     }
 
     /**

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -110,14 +110,8 @@ class OSIABWebViewActivity : AppCompatActivity() {
         onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (!webView.canGoBack()) return
-                if (options.hardwareBack) {
-                    hideErrorScreen()
-                    webView.goBack()
-                } else {
-                    // if hardwareBack is false, we want to finish the activity (close the WebView)
-                    // and not go back in the WebView history
-                    finish()
-                }
+                hideErrorScreen()
+                webView.goBack()
             }
         }
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
@@ -403,9 +397,10 @@ class OSIABWebViewActivity : AppCompatActivity() {
         override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
             // to implement predictive back navigation
             // we only want to have the callback enabled if the WebView can go back to previous page
+            // and if the hardwareBack option is enabled
             // if not, we want the system to handle the back press, which will enable the
-            // predictive back animation
-            onBackPressedCallback.isEnabled = webView.canGoBack()
+            // predictive back animation and simply close the WebView
+            onBackPressedCallback.isEnabled = webView.canGoBack() && options.hardwareBack
         }
 
         /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Migrates back navigation on `OSIABWebViewActivity.kt` replacing the deprecated `onBackPressed` override with  `onBackPressedDispatcher` and `OnBackPressedCallback`, following the recommendation from the [Android 16 Behaviour Changes documentation page](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back).
- Also enables predictive back navigation on when closing the WebView on `OSIABWebViewActivity.kt` for Android 13+.
- Also updates the library to Android 16 (API 36) - `targetSdk` and `compileSdk` updated.
- And also updates other versions: Kotlin, AGP, Gradle.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4335

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

[MABS 11 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=ae1e658e05fcca4d300af28c66a00fd3c165974e&stg=prd)

[MABS 10 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=d3c1f33ab7502fa0fb97aedbfb7ffae8918d9a0c&stg=prd)

No MABS 12 build yet because the Capacitor plugin wasn't updated yet. There should be no differences though, because all the changes are done here at the library side.

### Instructions on how to test:

1. Start by testing the plugin with an Android 15 build by simply using the MABS build or building your own.
2. Use the `openInWebView` client action using our InAppBrowser Sample App and test the back button navigation. Test clicking/gesturing the back button right after opening the WebView, which should close the WebView and return to the sample app screen. Also test navigating inside the WebView to other URLs, and then clicking/gesturing the back button to go back in the URLs.
3. Also test the predictive back navigation animation that should occur when closing the WebView with the back button gesture.
4. Then, to test the plugin with an Android 16 build (an app targeting Android 16), since there is currently no MABS version available that targets Android 16, you need to do that yourself.
5. Download the source code for the build and open it on Android Studio
6. Update the app to Android 16: This includes changing targetSdk, compileSdk in the app-level Gradle file, then possibly also updating the AGP version in the project-level Gradle file and the Gradle version in `gradle-wrapper.properties`.
7. Test the plugin / app again, and confirm that the behaviour remains the same - clicking/gesturing the back button has the correct behaviour.

## Screenshots / Screen recordings (if appropriate)

### Predictive back navigation animation

https://github.com/user-attachments/assets/1fb22c63-fac8-4d14-8c06-9f32f0c710aa

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
