### PR TITLE
fix: separate local storage between WebView processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0]
+
+### Fixes
+
+- Fix issue with local storage isolation between WebView and main app on Android 28+ [RMET-4918](https://outsystemsrd.atlassian.net/browse/RMET-4918)
+
 ## [1.6.1]
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>1.6.1</version>
+    <version>1.7.0</version>
 </project>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".views.OSIABWebViewActivity"
             android:exported="false"
+            android:process=":OSInAppBrowser"
             android:configChanges="orientation|screenSize|uiMode"
             android:label="OSIABWebViewActivity"
             android:theme="@style/AppTheme.WebView"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -23,6 +23,14 @@
             android:theme="@style/AppTheme.WebView"
             android:enableOnBackInvokedCallback="true"
             tools:targetApi="33" />
+        <activity
+            android:name=".views.OSIABWebViewActivitySharing"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|uiMode"
+            android:label="OSIABWebViewActivity"
+            android:theme="@style/AppTheme.WebView"
+            android:enableOnBackInvokedCallback="true"
+            tools:targetApi="33" />
         <activity android:name=".views.OSIABCustomTabsControllerActivity"
             android:exported="false"
             android:theme="@style/Theme.Transparent"

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
@@ -1,11 +1,11 @@
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib
 
-import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivity
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -25,41 +25,49 @@ sealed class OSIABEvents : Serializable {
     data class BrowserPageLoaded(override val browserId: String) : OSIABEvents()
     data class BrowserFinished(override val browserId: String) : OSIABEvents()
     data class BrowserPageNavigationCompleted(override val browserId: String, val url: String?) : OSIABEvents()
-
     data class OSIABCustomTabsEvent(
         override val browserId: String,
         val action: String,
-        val context: Context
+        @Transient val context: Context? = null
     ) : OSIABEvents()
+    
     data class OSIABWebViewEvent(
         override val browserId: String,
-        val activity: OSIABWebViewActivity? = null
+        @Transient val activity: OSIABWebViewActivity? = null
     ) : OSIABEvents()
 
     companion object {
         const val EXTRA_BROWSER_ID = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EXTRA_BROWSER_ID"
         const val ACTION_IAB_EVENT = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_IAB_EVENT"
+        const val ACTION_CLOSE_WEBVIEW = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_CLOSE_WEBVIEW"
         const val EXTRA_EVENT_DATA = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EXTRA_EVENT_DATA"
 
+        // Buffer capacity is required because BroadcastReceiver.onReceive() is synchronous.
+        // We must use tryEmit() which would drop events without buffer space.
         private val _events = MutableSharedFlow<OSIABEvents>(extraBufferCapacity = 64)
         val events = _events.asSharedFlow()
 
         private var receiver: BroadcastReceiver? = null
+        private var receiverRefCount = 0
 
-        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        /**
+         * Registers a BroadcastReceiver to listen for events from the isolated WebView process.
+         * This must be called before opening a WebView on Android 9+ to ensure events are received.
+         */
+        @Synchronized
         fun registerReceiver(context: Context) {
+            receiverRefCount++
             if (receiver != null) return
 
             val appContext = context.applicationContext
             receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {
                     if (intent?.action == ACTION_IAB_EVENT) {
-                        @Suppress("DEPRECATION")
-                        val event = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            intent.getSerializableExtra(EXTRA_EVENT_DATA, OSIABEvents::class.java)
-                        } else {
-                            intent.getSerializableExtra(EXTRA_EVENT_DATA) as? OSIABEvents
-                        }
+                        val event = IntentCompat.getSerializableExtra(
+                            intent,
+                            EXTRA_EVENT_DATA,
+                            OSIABEvents::class.java
+                        )
                         event?.let {
                             _events.tryEmit(it)
                         }
@@ -68,10 +76,33 @@ sealed class OSIABEvents : Serializable {
             }
 
             val filter = IntentFilter(ACTION_IAB_EVENT)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                appContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
-            } else {
-                appContext.registerReceiver(receiver, filter)
+            ContextCompat.registerReceiver(
+                appContext,
+                receiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+            )
+        }
+
+        /**
+         * Unregisters the BroadcastReceiver. Should be called when the browser is closed.
+         * The receiver is only truly unregistered when all registered 'users' have unregistered.
+         */
+        @Synchronized
+        fun unregisterReceiver(context: Context) {
+            if (receiverRefCount > 0) {
+                receiverRefCount--
+            }
+            
+            if (receiverRefCount == 0) {
+                receiver?.let {
+                    try {
+                        context.applicationContext.unregisterReceiver(it)
+                    } catch (e: Exception) {
+                        // Receiver may not be registered, ignore
+                    }
+                    receiver = null
+                }
             }
         }
 
@@ -79,6 +110,10 @@ sealed class OSIABEvents : Serializable {
             _events.emit(event)
         }
 
+        /**
+         * Broadcasts an event from the isolated WebView process to the main process.
+         * Only data-only events should be broadcast (BrowserPageLoaded, BrowserFinished, etc.).
+         */
         fun broadcastEvent(context: Context, event: OSIABEvents) {
             val intent = Intent(ACTION_IAB_EVENT).apply {
                 setPackage(context.packageName)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.content.ContextCompat
 import androidx.core.content.IntentCompat
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivity
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Serializable
@@ -32,8 +31,7 @@ sealed class OSIABEvents : Serializable {
     ) : OSIABEvents()
     
     data class OSIABWebViewEvent(
-        override val browserId: String,
-        @Transient val activity: OSIABWebViewActivity? = null
+        override val browserId: String
     ) : OSIABEvents()
 
     companion object {

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABEvents.kt
@@ -1,11 +1,25 @@
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib
 
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivity
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import java.io.Serializable
 
-sealed class OSIABEvents {
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API requires a prior call to OSIABEvents.registerReceiver(context) to work correctly with process isolation on Android 9+."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+annotation class RequiresEventBridgeRegistration
+
+sealed class OSIABEvents : Serializable {
     abstract val browserId: String
 
     data class BrowserPageLoaded(override val browserId: String) : OSIABEvents()
@@ -19,17 +33,58 @@ sealed class OSIABEvents {
     ) : OSIABEvents()
     data class OSIABWebViewEvent(
         override val browserId: String,
-        val activity: OSIABWebViewActivity
+        val activity: OSIABWebViewActivity? = null
     ) : OSIABEvents()
 
     companion object {
         const val EXTRA_BROWSER_ID = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EXTRA_BROWSER_ID"
+        const val ACTION_IAB_EVENT = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.ACTION_IAB_EVENT"
+        const val EXTRA_EVENT_DATA = "com.outsystems.plugins.inappbrowser.osinappbrowserlib.EXTRA_EVENT_DATA"
 
-        private val _events = MutableSharedFlow<OSIABEvents>()
+        private val _events = MutableSharedFlow<OSIABEvents>(extraBufferCapacity = 64)
         val events = _events.asSharedFlow()
+
+        private var receiver: BroadcastReceiver? = null
+
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        fun registerReceiver(context: Context) {
+            if (receiver != null) return
+
+            val appContext = context.applicationContext
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    if (intent?.action == ACTION_IAB_EVENT) {
+                        @Suppress("DEPRECATION")
+                        val event = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            intent.getSerializableExtra(EXTRA_EVENT_DATA, OSIABEvents::class.java)
+                        } else {
+                            intent.getSerializableExtra(EXTRA_EVENT_DATA) as? OSIABEvents
+                        }
+                        event?.let {
+                            _events.tryEmit(it)
+                        }
+                    }
+                }
+            }
+
+            val filter = IntentFilter(ACTION_IAB_EVENT)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                appContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                appContext.registerReceiver(receiver, filter)
+            }
+        }
 
         suspend fun postEvent(event: OSIABEvents) {
             _events.emit(event)
+        }
+
+        fun broadcastEvent(context: Context, event: OSIABEvents) {
+            val intent = Intent(ACTION_IAB_EVENT).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_EVENT_DATA, event)
+            }
+            context.sendBroadcast(intent)
         }
     }
 

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
@@ -11,6 +11,7 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABCustomTabsControllerActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -35,6 +36,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     ) {
+        OSIABEvents.registerReceiver(context)
         CustomTabsClient.bindCustomTabsService(
             context,
             packageName,
@@ -54,6 +56,7 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         )
     }
 
+    @OptIn(RequiresEventBridgeRegistration::class)
     private inner class CustomTabsCallbackImpl(
         private val browserId: String,
         private val lifecycleScope: CoroutineScope,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABCustomTabsSessionHelper.kt
@@ -1,3 +1,5 @@
+@file:OptIn(com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration::class)
+
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers
 
 import android.content.ComponentName
@@ -11,7 +13,6 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABCustomTabsControllerActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -36,7 +37,6 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         flowHelper: OSIABFlowHelperInterface,
         customTabsSessionCallback: (CustomTabsSession?) -> Unit
     ) {
-        OSIABEvents.registerReceiver(context)
         CustomTabsClient.bindCustomTabsService(
             context,
             packageName,
@@ -56,7 +56,6 @@ class OSIABCustomTabsSessionHelper: OSIABCustomTabsSessionHelperInterface {
         )
     }
 
-    @OptIn(RequiresEventBridgeRegistration::class)
     private inner class CustomTabsCallbackImpl(
         private val browserId: String,
         private val lifecycleScope: CoroutineScope,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelper.kt
@@ -1,6 +1,7 @@
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers
 
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.transformWhile
@@ -14,7 +15,11 @@ class OSIABFlowHelper: OSIABFlowHelperInterface {
      * @param browserId Identifier for the browser instance to emit events to
      * @param scope CoroutineScope to launch
      * @param onEventReceived callback to send the collected event in
+     *
+     * @note For Android API 28+, you must call [OSIABEvents.registerReceiver] once during your application
+     * or activity lifecycle to ensure events from the isolated browser process are correctly received and bridged.
      */
+    @RequiresEventBridgeRegistration
     override fun listenToEvents(
         browserId: String,
         scope: CoroutineScope,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelperInterface.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelperInterface.kt
@@ -1,6 +1,7 @@
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers
 
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 
@@ -12,7 +13,11 @@ interface OSIABFlowHelperInterface {
      * @param browserId Identifier for the browser instance to emit events to
      * @param scope CoroutineScope to launch
      * @param onEventReceived callback to send the collected event in
+     *
+     * @note For Android API 28+, you must call [OSIABEvents.registerReceiver] once during your application
+     * or activity lifecycle to ensure events from the isolated browser process are correctly received and bridged.
      */
+    @RequiresEventBridgeRegistration
     fun listenToEvents(
         browserId: String,
         scope: CoroutineScope,

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/models/OSIABWebViewOptions.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/models/OSIABWebViewOptions.kt
@@ -16,5 +16,6 @@ data class OSIABWebViewOptions(
     @SerializedName("allowZoom") val allowZoom: Boolean = true,
     @SerializedName("hardwareBack") val hardwareBack: Boolean = true,
     @SerializedName("pauseMedia") val pauseMedia: Boolean = true,
-    @SerializedName("customUserAgent") val customUserAgent: String? = null
+    @SerializedName("customUserAgent") val customUserAgent: String? = null,
+    @SerializedName("isIsolated") val isIsolated: Boolean = true
 ) : OSIABOptions, Serializable

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -1,3 +1,5 @@
+@file:OptIn(com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration::class)
+
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib.routeradapters
 
 import android.content.Context
@@ -6,7 +8,6 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelper
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelperInterface
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABFlowHelperInterface
@@ -40,10 +41,13 @@ class OSIABCustomTabsRouterAdapter(
 
     // for the browserPageLoaded event, which we only want to trigger on the first URL loaded in the CustomTabs instance
     private var isFirstLoad = true
+    private var isFinished = false
 
-    @OptIn(RequiresEventBridgeRegistration::class)
     override fun close(completionHandler: (Boolean) -> Unit) {
-        OSIABEvents.registerReceiver(context)
+        if (isFinished) {
+            completionHandler(true)
+            return
+        }
         var closeEventJob: Job? = null
 
         closeEventJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
@@ -144,7 +148,6 @@ class OSIABCustomTabsRouterAdapter(
     }
 
     override fun handleOpen(url: String, completionHandler: (Boolean) -> Unit) {
-        OSIABEvents.registerReceiver(context)
         lifecycleScope.launch {
             try {
                 val uri = Uri.parse(url)
@@ -169,7 +172,6 @@ class OSIABCustomTabsRouterAdapter(
         }
     }
 
-    @OptIn(RequiresEventBridgeRegistration::class)
     private fun openCustomTabsIntent(session: CustomTabsSession, uri: Uri, completionHandler: (Boolean) -> Unit) {
         val customTabsIntent = buildCustomTabsIntent(session)
         var eventsJob: Job? = null
@@ -178,13 +180,16 @@ class OSIABCustomTabsRouterAdapter(
                 is OSIABEvents.OSIABCustomTabsEvent -> {
                     if(event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_READY) {
                         try {
-                            customTabsIntent.launchUrl(event.context, uri)
-                            completionHandler(true)
+                            event.context?.let { ctx ->
+                                customTabsIntent.launchUrl(ctx, uri)
+                                completionHandler(true)
+                            } ?: completionHandler(false)
                         } catch (e: Exception) {
                             completionHandler(false)
                         }
                     }
                     else if(event.action == OSIABCustomTabsControllerActivity.EVENT_CUSTOM_TABS_DESTROYED) {
+                        isFinished = true
                         onBrowserFinished()
                         eventsJob?.cancel()
                     }
@@ -198,6 +203,7 @@ class OSIABCustomTabsRouterAdapter(
                 is OSIABEvents.BrowserFinished -> {
                     // Ensure that custom tabs controller activity is fully destroyed
                     startCustomTabsControllerActivity(true)
+                    isFinished = true
                     onBrowserFinished()
                     eventsJob?.cancel()
                 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABCustomTabsRouterAdapter.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsSession
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelper
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABCustomTabsSessionHelperInterface
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABFlowHelperInterface
@@ -40,7 +41,9 @@ class OSIABCustomTabsRouterAdapter(
     // for the browserPageLoaded event, which we only want to trigger on the first URL loaded in the CustomTabs instance
     private var isFirstLoad = true
 
+    @OptIn(RequiresEventBridgeRegistration::class)
     override fun close(completionHandler: (Boolean) -> Unit) {
+        OSIABEvents.registerReceiver(context)
         var closeEventJob: Job? = null
 
         closeEventJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
@@ -141,6 +144,7 @@ class OSIABCustomTabsRouterAdapter(
     }
 
     override fun handleOpen(url: String, completionHandler: (Boolean) -> Unit) {
+        OSIABEvents.registerReceiver(context)
         lifecycleScope.launch {
             try {
                 val uri = Uri.parse(url)
@@ -165,6 +169,7 @@ class OSIABCustomTabsRouterAdapter(
         }
     }
 
+    @OptIn(RequiresEventBridgeRegistration::class)
     private fun openCustomTabsIntent(session: CustomTabsSession, uri: Uri, completionHandler: (Boolean) -> Unit) {
         val customTabsIntent = buildCustomTabsIntent(session)
         var eventsJob: Job? = null

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridgeRegistration
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABFlowHelperInterface
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.models.OSIABWebViewOptions
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivity
@@ -71,10 +72,12 @@ class OSIABWebViewRouterAdapter(
      * @param url URL to be opened.
      * @param completionHandler The callback with the result of opening the url.
      */
+    @OptIn(RequiresEventBridgeRegistration::class)
     override fun handleOpen(url: String, completionHandler: (Boolean) -> Unit) {
         lifecycleScope.launch {
             try {
                 // Collect the browser events
+                OSIABEvents.registerReceiver(context)
                 var eventsJob: Job? = null
                 eventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
                     when (event) {

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -85,10 +85,10 @@ class OSIABWebViewRouterAdapter(
     @OptIn(RequiresEventBridgeRegistration::class)
     override fun handleOpen(url: String, completionHandler: (Boolean) -> Unit) {
         lifecycleScope.launch {
+            var eventsJob: Job? = null
             try {
                 // Collect the browser events
                 OSIABEvents.registerReceiver(context)
-                var eventsJob: Job? = null
                 eventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
                     when (event) {
                         is OSIABEvents.OSIABWebViewEvent -> {
@@ -124,7 +124,8 @@ class OSIABWebViewRouterAdapter(
                 )
 
             } catch (e: Exception) {
-                finalizeBrowser()
+                eventsJob?.cancel()
+                OSIABEvents.unregisterReceiver(context)
                 completionHandler(false)
             }
         }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -8,6 +8,7 @@ import com.outsystems.plugins.inappbrowser.osinappbrowserlib.RequiresEventBridge
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABFlowHelperInterface
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.models.OSIABWebViewOptions
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivity
+import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewActivitySharing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -108,9 +109,15 @@ class OSIABWebViewRouterAdapter(
                     }
                 }
 
+                val activityClass = if (options.isIsolated) {
+                    OSIABWebViewActivity::class.java
+                } else {
+                    OSIABWebViewActivitySharing::class.java
+                }
+
                 context.startActivity(
                     Intent(
-                        context, OSIABWebViewActivity::class.java
+                        context, activityClass
                     ).apply {
                         putExtra(OSIABEvents.EXTRA_BROWSER_ID, browserId)
                         putExtra(WEB_VIEW_URL_EXTRA, url)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -59,13 +59,6 @@ class OSIABWebViewRouterAdapter(
             return
         }
 
-        // Send close broadcast to the WebView process
-        val closeIntent = Intent(OSIABEvents.ACTION_CLOSE_WEBVIEW).apply {
-            setPackage(context.packageName)
-            putExtra(OSIABEvents.EXTRA_BROWSER_ID, browserId)
-        }
-        context.sendBroadcast(closeIntent)
-
         // Listen for the BrowserFinished event to confirm close
         var closeJob: Job? = null
         closeJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
@@ -75,6 +68,13 @@ class OSIABWebViewRouterAdapter(
                 closeJob?.cancel()
             }
         }
+
+        // Send close broadcast to the WebView process
+        val closeIntent = Intent(OSIABEvents.ACTION_CLOSE_WEBVIEW).apply {
+            setPackage(context.packageName)
+            putExtra(OSIABEvents.EXTRA_BROWSER_ID, browserId)
+        }
+        context.sendBroadcast(closeIntent)
     }
 
     /**

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/routeradapters/OSIABWebViewRouterAdapter.kt
@@ -11,7 +11,6 @@ import com.outsystems.plugins.inappbrowser.osinappbrowserlib.views.OSIABWebViewA
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import java.lang.ref.WeakReference
 import java.util.UUID
 
 class OSIABWebViewRouterAdapter(
@@ -39,30 +38,41 @@ class OSIABWebViewRouterAdapter(
         const val CUSTOM_HEADERS_EXTRA = "CUSTOM_HEADERS_EXTRA"
     }
 
-    private var webViewActivityRef: WeakReference<OSIABWebViewActivity>? = null
+    private var isFinished = false
 
-    private fun setWebViewActivity(activity: OSIABWebViewActivity?) {
-        webViewActivityRef = if (activity == null) {
-            null
-        } else {
-            WeakReference(activity)
+    private fun finalizeBrowser() {
+        if (!isFinished) {
+            isFinished = true
+            onBrowserFinished()
+            OSIABEvents.unregisterReceiver(context)
         }
     }
 
-    private fun getWebViewActivity(): OSIABWebViewActivity? {
-        return webViewActivityRef?.get()
-    }
-
+    /**
+     * Closes the WebView by sending a broadcast to the separate process.
+     * The WebView activity will receive this and call finish() on itself.
+     */
+    @OptIn(RequiresEventBridgeRegistration::class)
     override fun close(completionHandler: (Boolean) -> Unit) {
-        getWebViewActivity().let { activity ->
-            if(activity == null) {
-                completionHandler(false)
-            }
-            else {
-                activity.finish()
-                setWebViewActivity(null)
-                onBrowserFinished()
+        if (isFinished) {
+            completionHandler(true)
+            return
+        }
+
+        // Send close broadcast to the WebView process
+        val closeIntent = Intent(OSIABEvents.ACTION_CLOSE_WEBVIEW).apply {
+            setPackage(context.packageName)
+            putExtra(OSIABEvents.EXTRA_BROWSER_ID, browserId)
+        }
+        context.sendBroadcast(closeIntent)
+
+        // Listen for the BrowserFinished event to confirm close
+        var closeJob: Job? = null
+        closeJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
+            if (event is OSIABEvents.BrowserFinished) {
+                finalizeBrowser()
                 completionHandler(true)
+                closeJob?.cancel()
             }
         }
     }
@@ -82,15 +92,13 @@ class OSIABWebViewRouterAdapter(
                 eventsJob = flowHelper.listenToEvents(browserId, lifecycleScope) { event ->
                     when (event) {
                         is OSIABEvents.OSIABWebViewEvent -> {
-                            setWebViewActivity(event.activity)
                             completionHandler(true)
                         }
                         is OSIABEvents.BrowserPageLoaded -> {
                             onBrowserPageLoaded()
                         }
                         is OSIABEvents.BrowserFinished -> {
-                            setWebViewActivity(null)
-                            onBrowserFinished()
+                            finalizeBrowser()
                             eventsJob?.cancel()
                         }
                         is OSIABEvents.BrowserPageNavigationCompleted -> {
@@ -116,6 +124,7 @@ class OSIABWebViewRouterAdapter(
                 )
 
             } catch (e: Exception) {
+                finalizeBrowser()
                 completionHandler(false)
             }
         }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -1,6 +1,7 @@
 package com.outsystems.plugins.inappbrowser.osinappbrowserlib.views
 
 import android.Manifest
+import android.app.Application
 import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -54,7 +55,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-class OSIABWebViewActivity : AppCompatActivity() {
+open class OSIABWebViewActivity : AppCompatActivity() {
 
     private lateinit var webView: WebView
     private lateinit var closeButton: TextView
@@ -154,7 +155,10 @@ class OSIABWebViewActivity : AppCompatActivity() {
         init {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 try {
-                    WebView.setDataDirectorySuffix("OSInAppBrowser")
+                    val processName = Application.getProcessName()
+                    if (processName.endsWith(":OSInAppBrowser")) {
+                        WebView.setDataDirectorySuffix("OSInAppBrowser")
+                    }
                 } catch (e: Exception) {
                     Log.d(LOG_TAG, "Suffix already set or error: ${e.message}")
                 }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -148,6 +148,15 @@ class OSIABWebViewActivity : AppCompatActivity() {
             return File.createTempFile("${prefix}${timeStamp}_", suffix, storageDir)
         }
 
+        init {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                try {
+                    WebView.setDataDirectorySuffix("OSInAppBrowser")
+                } catch (e: Exception) {
+                    Log.d(LOG_TAG, "Suffix already set or error: ${e.message}")
+                }
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -164,7 +173,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
         browserId = intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID) ?: ""
 
-        sendWebViewEvent(OSIABWebViewEvent(browserId, this@OSIABWebViewActivity))
+        sendWebViewEvent(OSIABEvents.OSIABWebViewEvent(browserId))
 
         appName = applicationInfo.loadLabel(packageManager).toString()
 
@@ -917,6 +926,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
     private fun sendWebViewEvent(event: OSIABEvents) {
         lifecycleScope.launch {
             OSIABEvents.postEvent(event)
+            OSIABEvents.broadcastEvent(this@OSIABWebViewActivity, event)
         }
     }
 

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -2,16 +2,18 @@ package com.outsystems.plugins.inappbrowser.osinappbrowserlib.views
 
 import android.Manifest
 import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
 import android.view.Gravity
-import android.graphics.Bitmap
 import android.view.View
 import android.webkit.CookieManager
 import android.webkit.GeolocationPermissions
@@ -39,7 +41,6 @@ import androidx.core.content.FileProvider
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents
-import com.outsystems.plugins.inappbrowser.osinappbrowserlib.OSIABEvents.OSIABWebViewEvent
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.R
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers.OSIABPdfHelper
 import com.outsystems.plugins.inappbrowser.osinappbrowserlib.models.OSIABToolbarPosition
@@ -68,6 +69,8 @@ class OSIABWebViewActivity : AppCompatActivity() {
     private lateinit var options: OSIABWebViewOptions
     private lateinit var appName: String
     private lateinit var browserId: String
+
+    private var closeReceiver: BroadcastReceiver? = null
 
     // for the browserPageLoaded event, which we only want to trigger on the first URL loaded in the WebView
     private var isFirstLoad = true
@@ -173,6 +176,23 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
         browserId = intent.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID) ?: ""
 
+        // Register receiver for close commands from main process
+        closeReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                val targetBrowserId = intent?.getStringExtra(OSIABEvents.EXTRA_BROWSER_ID)
+                if (targetBrowserId == browserId) {
+                    finish()
+                }
+            }
+        }
+        val filter = IntentFilter(OSIABEvents.ACTION_CLOSE_WEBVIEW)
+        ContextCompat.registerReceiver(
+            this,
+            closeReceiver,
+            filter,
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+
         sendWebViewEvent(OSIABEvents.OSIABWebViewEvent(browserId))
 
         appName = applicationInfo.loadLabel(packageManager).toString()
@@ -250,6 +270,14 @@ class OSIABWebViewActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        closeReceiver?.let {
+            try {
+                unregisterReceiver(it)
+            } catch (e: Exception) {
+                // Receiver may not be registered, ignore
+            }
+            closeReceiver = null
+        }
         webView.destroy()
         super.onDestroy()
     }
@@ -925,7 +953,6 @@ class OSIABWebViewActivity : AppCompatActivity() {
      */
     private fun sendWebViewEvent(event: OSIABEvents) {
         lifecycleScope.launch {
-            OSIABEvents.postEvent(event)
             OSIABEvents.broadcastEvent(this@OSIABWebViewActivity, event)
         }
     }

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivitySharing.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivitySharing.kt
@@ -1,0 +1,7 @@
+package com.outsystems.plugins.inappbrowser.osinappbrowserlib.views
+
+/**
+ * A non-isolated version of OSIABWebViewActivity that runs in the main app process.
+ * This is used when the user opts-out of storage isolation to share cookies/localStorage.
+ */
+class OSIABWebViewActivitySharing : OSIABWebViewActivity()

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABCustomTabsRouterAdapterTests.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABCustomTabsRouterAdapterTests.kt
@@ -109,7 +109,7 @@ class OSIABCustomTabsRouterAdapterTests {
     fun test_handleOpen_withValidURL_launchesCustomTab_when_browserPageLoaded_then_browserPageLoadedTriggered() {
         runTest(StandardTestDispatcher()) {
             val context = mockContext(useValidURL = true, ableToOpenURL = true)
-            val flowHelperMock = OSIABFlowHelperMock().apply { event = OSIABEvents.BrowserPageLoaded("") }
+            val flowHelperMock = OSIABFlowHelperMock().apply { events = listOf(OSIABEvents.BrowserPageLoaded("")) }
             val sut = OSIABCustomTabsRouterAdapter(
                 context = context,
                 lifecycleScope = this,
@@ -134,7 +134,7 @@ class OSIABCustomTabsRouterAdapterTests {
     fun test_handleOpen_withValidURL_launchesCustomTab_when_browserFinished_then_browserFinishedTriggered() {
         runTest(StandardTestDispatcher()) {
             val context = mockContext(useValidURL = true, ableToOpenURL = true)
-            val flowHelperMock = OSIABFlowHelperMock().apply { event = OSIABEvents.BrowserFinished("") }
+            val flowHelperMock = OSIABFlowHelperMock().apply { events = listOf(OSIABEvents.BrowserFinished("")) }
             val sut = OSIABCustomTabsRouterAdapter(
                 context = context,
                 lifecycleScope = this,

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABWebViewRouterAdapterTests.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/OSIABWebViewRouterAdapterTests.kt
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -70,7 +71,7 @@ class OSIABWebViewRouterAdapterTests {
     fun test_handleOpen_ableToOpenIt_returnsTrue_and_when_browserFinished_then_browserFinishedTriggered() =
         runTest(StandardTestDispatcher()) {
             val context = mockContext(ableToOpenURL = true)
-            val flowHelperMock = OSIABFlowHelperMock().apply { event = OSIABEvents.BrowserFinished("") }
+            val flowHelperMock = OSIABFlowHelperMock().apply { events = listOf(OSIABEvents.BrowserFinished("")) }
             val sut = OSIABWebViewRouterAdapter(
                 context = context,
                 lifecycleScope = this,
@@ -95,7 +96,10 @@ class OSIABWebViewRouterAdapterTests {
             var pageNavigationCalled = false
             val context = mockContext(ableToOpenURL = true)
             val flowHelperMock = OSIABFlowHelperMock().apply {
-                event = OSIABEvents.BrowserPageNavigationCompleted("", "https://test")
+                events = listOf(
+                    OSIABEvents.BrowserPageNavigationCompleted("", "https://test"),
+                    OSIABEvents.OSIABWebViewEvent("")
+                )
             }
             val sut = OSIABWebViewRouterAdapter(
                 context = context,
@@ -123,6 +127,7 @@ class OSIABWebViewRouterAdapterTests {
 
     private fun mockContext(ableToOpenURL: Boolean = false): Context {
         val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(context)
         if (!ableToOpenURL) {
             doThrow(RuntimeException("Unable to open URL")).`when`(context).startActivity(any(Intent::class.java))
         }

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelperMock.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABFlowHelperMock.kt
@@ -7,13 +7,13 @@ import org.mockito.Mockito.mock
 
 class OSIABFlowHelperMock: OSIABFlowHelperInterface {
 
-    var event: OSIABEvents = OSIABEvents.BrowserPageLoaded("")
+    var events: List<OSIABEvents> = emptyList()
     override fun listenToEvents(
         browserId: String,
         scope: CoroutineScope,
         onEventReceived: (OSIABEvents) -> Unit
     ): Job {
-        onEventReceived(event)
+        events.forEach { onEventReceived(it) }
         return mock(Job::class.java)
     }
 }


### PR DESCRIPTION
## Description
This PR implements localStorage isolation on Android API 28+ via [setDataDirectorySuffix](https://developer.android.com/reference/android/webkit/WebView#setDataDirectorySuffix(java.lang.String)), bringing it into alignment with iOS behavior. 

Due to Android system limitations, isolation can only be achieved by running the WebView in a separate `:OSInAppBrowser` process with a dedicated data directory suffix. This requires events to be propagated between the processes via broadcast receivers. To avoid a breaking change, we keep the class signatures the same and add a custom `@RequiresEventBridgeRegistration` annotation to proactively warn native library users of the new registration requirement.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4918?atlOrigin=eyJpIjoiOWI4NWVmMDIwZDhhNDRmMGJhMTljMWFlNTQxYmFkZjIiLCJwIjoiaiJ9

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

