### PR TITLE
fix: Duplicate Requests for checking if a url hosts PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2]
+
+### Fixes
+
+- Replace HEAD / GET request for checking if file is PDF, with WebKit's [DownloadListener](https://developer.android.com/reference/android/webkit/DownloadListener). This makes sure that for non-PDF urls, no extra request is done [RMET-5141](https://outsystemsrd.atlassian.net/browse/RMET-5141) / [RPM-6744](https://outsystemsrd.atlassian.net/browse/RPM-6744) 
+
 ## [1.6.1]
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABPdfHelper.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABPdfHelper.kt
@@ -3,53 +3,12 @@ package com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers
 import android.content.Context
 import java.io.File
 import java.io.IOException
-import java.net.HttpURLConnection
 import java.net.URL
 
 object OSIABPdfHelper {
 
-    interface UrlFactory {
-        fun create(url: String): URL
-    }
-
-    private class DefaultUrlFactory : UrlFactory {
-        override fun create(url: String): URL = URL(url)
-    }
-    
-    fun isContentTypeApplicationPdf(urlString: String): Boolean {
-        return try {
-            // Try to identify if the URL is a PDF using a HEAD request.
-            // If the server does not implement HEAD correctly or does not return the expected content-type,
-            // fall back to a GET request, since some servers only return the correct type for GET.
-            if (checkPdfByRequest(urlString, method = "HEAD")) {
-                true
-            } else {
-                checkPdfByRequest(urlString, method = "GET")
-            }
-        } catch (_: Exception) {
-            false
-        }
-    }
-
-    fun checkPdfByRequest(urlString: String, method: String, urlFactory: UrlFactory = DefaultUrlFactory()): Boolean {
-        var conn: HttpURLConnection? = null
-        return try {
-            conn = (urlFactory.create(urlString).openConnection() as? HttpURLConnection)
-            conn?.run {
-                instanceFollowRedirects = true
-                requestMethod = method
-                if (method == "GET") {
-                    setRequestProperty("Range", "bytes=0-0")
-                }
-                connect()
-                val type = contentType?.lowercase()
-                val disposition = getHeaderField("Content-Disposition")?.lowercase()
-                type == "application/pdf" ||
-                        (type.isNullOrEmpty() && disposition?.contains(".pdf") == true)
-            } ?: false
-        } finally {
-            conn?.disconnect()
-        }
+    fun isPdf(mimeType: String?, contentDisposition: String?): Boolean {
+        return mimeType == "application/pdf" || contentDisposition?.contains(".pdf") == true
     }
 
     @Throws(IOException::class)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -219,28 +219,6 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
         setupWebView()
 
-        webView.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
-            Log.e("downloadlistener", "mimeType=$mimeType, contentDisposition=$contentDisposition url=$url")
-            if ((mimeType == "application/pdf" || contentDisposition.contains(".pdf")) && !url.startsWith(PDF_VIEWER_URL_PREFIX)) {
-                lifecycleScope.launch(Dispatchers.IO) {
-                    val pdfFile = try {
-                        OSIABPdfHelper.downloadPdfToCache(this@OSIABWebViewActivity, url)
-                    } catch (_: IOException) {
-                        null
-                    }
-                    if (pdfFile != null) {
-                        withContext(Dispatchers.Main) {
-                            webView.stopLoading()
-                            originalUrl = url
-                            val pdfJsUrl =
-                                PDF_VIEWER_URL_PREFIX + Uri.encode("file://${pdfFile.absolutePath}")
-                            webView.loadUrl(pdfJsUrl)
-                        }
-                    }
-                }
-            }
-        }
-
         if (urlToOpen != null) {
             handleLoadUrl(urlToOpen, customHeaders)
             showLoadingScreen()
@@ -332,6 +310,14 @@ class OSIABWebViewActivity : AppCompatActivity() {
                 options.showURL && options.showToolbar
             )
         webView.webChromeClient = customWebChromeClient()
+
+        webView.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
+            handleWebViewDownload(
+                url = url,
+                mimeType = mimeType,
+                contentDisposition = contentDisposition
+            )
+        }
     }
 
     /**
@@ -349,6 +335,38 @@ class OSIABWebViewActivity : AppCompatActivity() {
      */
     private fun customWebChromeClient(): WebChromeClient {
         return OSIABWebChromeClient()
+    }
+
+    /**
+     * Implement the WebKit DownloadListener and handle downloading and previewing PDF files
+     */
+    private fun handleWebViewDownload(
+        url: String?,
+        mimeType: String?,
+        contentDisposition: String?
+    ) {
+        if ((mimeType == "application/pdf" || (contentDisposition?.contains(".pdf") == true)) &&
+            (!url.isNullOrEmpty() && !url.startsWith(PDF_VIEWER_URL_PREFIX))
+        ) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                val pdfFile = try {
+                    OSIABPdfHelper.downloadPdfToCache(this@OSIABWebViewActivity, url)
+                } catch (_: IOException) {
+                    // can happen if we try to press the "save" button in pdf viewer
+                    //  which returns a blob url that we won't be able to download
+                    null
+                }
+                if (pdfFile != null) {
+                    withContext(Dispatchers.Main) {
+                        webView.stopLoading()
+                        originalUrl = url
+                        val pdfJsUrl =
+                            PDF_VIEWER_URL_PREFIX + Uri.encode("file://${pdfFile.absolutePath}")
+                        webView.loadUrl(pdfJsUrl)
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -819,7 +837,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
         if (!showNavigationButtons) {
             navigationView.removeView(nav)
         } else defineNavigationButtons(isLeftRight, content)
-        
+
         if (!showURL) navigationView.removeView(urlText)
         else defineURLView(url, showNavigationButtons, navigationView, toolbarPosition, isLeftRight)
 

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -254,7 +254,11 @@ class OSIABWebViewActivity : AppCompatActivity() {
     }
 
     private fun handleLoadUrl(url: String, additionalHttpHeaders: Map<String, String>? = null) {
-        webView.loadUrl(url, additionalHttpHeaders ?: emptyMap())
+        if (additionalHttpHeaders.isNullOrEmpty()) {
+            webView.loadUrl(url)
+        } else {
+            webView.loadUrl(url, additionalHttpHeaders)
+        }
     }
 
 

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -218,6 +218,29 @@ class OSIABWebViewActivity : AppCompatActivity() {
         enableThirdPartyCookies()
 
         setupWebView()
+
+        webView.setDownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
+            Log.e("downloadlistener", "mimeType=$mimetype, url=$url")
+            if (mimetype == "application/pdf" && !url.startsWith(PDF_VIEWER_URL_PREFIX)) {
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val pdfFile = try {
+                        OSIABPdfHelper.downloadPdfToCache(this@OSIABWebViewActivity, url)
+                    } catch (_: IOException) {
+                        null
+                    }
+                    if (pdfFile != null) {
+                        withContext(Dispatchers.Main) {
+                            webView.stopLoading()
+                            originalUrl = url
+                            val pdfJsUrl =
+                                PDF_VIEWER_URL_PREFIX + Uri.encode("file://${pdfFile.absolutePath}")
+                            webView.loadUrl(pdfJsUrl)
+                        }
+                    }
+                }
+            }
+        }
+
         if (urlToOpen != null) {
             handleLoadUrl(urlToOpen, customHeaders)
             showLoadingScreen()
@@ -253,25 +276,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
     }
 
     private fun handleLoadUrl(url: String, additionalHttpHeaders: Map<String, String>? = null) {
-        lifecycleScope.launch(Dispatchers.IO) {
-            if (OSIABPdfHelper.isContentTypeApplicationPdf(url)) {
-                val pdfFile = try { OSIABPdfHelper.downloadPdfToCache(this@OSIABWebViewActivity, url) } catch (_: IOException) { null }
-                if (pdfFile != null) {
-                    withContext(Dispatchers.Main) {
-                        webView.stopLoading()
-                        originalUrl = url
-                        val pdfJsUrl =
-                            PDF_VIEWER_URL_PREFIX + Uri.encode("file://${pdfFile.absolutePath}")
-                        webView.loadUrl(pdfJsUrl)
-                    }
-                    return@launch
-                }
-            }
-
-            withContext(Dispatchers.Main) {
-                webView.loadUrl(url, additionalHttpHeaders ?: emptyMap())
-            }
-        }
+        webView.loadUrl(url, additionalHttpHeaders ?: emptyMap())
     }
 
 

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -219,9 +219,9 @@ class OSIABWebViewActivity : AppCompatActivity() {
 
         setupWebView()
 
-        webView.setDownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
-            Log.e("downloadlistener", "mimeType=$mimetype, url=$url")
-            if (mimetype == "application/pdf" && !url.startsWith(PDF_VIEWER_URL_PREFIX)) {
+        webView.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
+            Log.e("downloadlistener", "mimeType=$mimeType, contentDisposition=$contentDisposition url=$url")
+            if ((mimeType == "application/pdf" || contentDisposition.contains(".pdf")) && !url.startsWith(PDF_VIEWER_URL_PREFIX)) {
                 lifecycleScope.launch(Dispatchers.IO) {
                     val pdfFile = try {
                         OSIABPdfHelper.downloadPdfToCache(this@OSIABWebViewActivity, url)

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -345,7 +345,7 @@ class OSIABWebViewActivity : AppCompatActivity() {
         mimeType: String?,
         contentDisposition: String?
     ) {
-        if ((mimeType == "application/pdf" || (contentDisposition?.contains(".pdf") == true)) &&
+        if (OSIABPdfHelper.isPdf(mimeType, contentDisposition) &&
             (!url.isNullOrEmpty() && !url.startsWith(PDF_VIEWER_URL_PREFIX))
         ) {
             lifecycleScope.launch(Dispatchers.IO) {

--- a/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABPdfHelperTest.kt
+++ b/src/test/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/helpers/OSIABPdfHelperTest.kt
@@ -3,175 +3,51 @@ package com.outsystems.plugins.inappbrowser.osinappbrowserlib.helpers
 import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
-import io.mockk.verify
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.net.HttpURLConnection
 import java.net.ServerSocket
 import java.net.Socket
-import java.net.URL
 import java.nio.file.Files
 import kotlin.concurrent.thread
 
 class OSIABPdfHelperTest {
 
+    // region isPdf
+
     @Test
-    fun `isContentTypeApplicationPdf returns true if HEAD is PDF`() {
-        mockkObject(OSIABPdfHelper)
-        every { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) } returns true
-
-        val result = OSIABPdfHelper.isContentTypeApplicationPdf("http://example.com")
-
-        assertTrue(result)
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) }
-        verify(exactly = 0) { OSIABPdfHelper.checkPdfByRequest(any(), "GET", any()) }
-        unmockkObject(OSIABPdfHelper)
+    fun `isPdf returns true when mimeType is application pdf`() {
+        assertTrue(OSIABPdfHelper.isPdf("application/pdf", null))
     }
 
     @Test
-    fun `isContentTypeApplicationPdf falls back to GET if HEAD fails`() {
-        mockkObject(OSIABPdfHelper)
-        every { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) } returns false
-        every { OSIABPdfHelper.checkPdfByRequest(any(), "GET", any()) } returns true
-
-        val result = OSIABPdfHelper.isContentTypeApplicationPdf("http://example.com")
-
-        assertTrue(result)
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) }
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "GET", any()) }
-        unmockkObject(OSIABPdfHelper)
+    fun `isPdf returns true when contentDisposition contains pdf extension`() {
+        assertTrue(OSIABPdfHelper.isPdf(null, "attachment; filename=test.pdf"))
     }
 
     @Test
-    fun `isContentTypeApplicationPdf returns false if both HEAD and GET fail`() {
-        mockkObject(OSIABPdfHelper)
-        every { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) } returns false
-        every { OSIABPdfHelper.checkPdfByRequest(any(), "GET", any()) } returns false
-
-        val result = OSIABPdfHelper.isContentTypeApplicationPdf("http://example.com")
-
-        assertFalse(result)
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) }
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "GET", any()) }
-        unmockkObject(OSIABPdfHelper)
+    fun `isPdf returns true when both mimeType and contentDisposition indicate pdf`() {
+        assertTrue(OSIABPdfHelper.isPdf("application/pdf", "attachment; filename=test.pdf"))
     }
 
     @Test
-    fun `isContentTypeApplicationPdf returns false if exception occurs`() {
-        mockkObject(OSIABPdfHelper)
-        every {
-            OSIABPdfHelper.checkPdfByRequest(
-                any(),
-                any(),
-                any()
-            )
-        } throws RuntimeException("Network error")
-
-        val result = OSIABPdfHelper.isContentTypeApplicationPdf("http://example.com")
-
-        assertFalse(result)
-        verify { OSIABPdfHelper.checkPdfByRequest(any(), "HEAD", any()) }
-        unmockkObject(OSIABPdfHelper)
+    fun `isPdf returns true when mimeType is not pdf but contentDisposition contains pdf extension`() {
+        assertTrue(OSIABPdfHelper.isPdf("text/html", "attachment; filename=report.pdf"))
     }
 
     @Test
-    fun `returns true when content type is application_pdf`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        val url = mockk<URL>()
-        val conn = mockk<HttpURLConnection>(relaxed = true)
-        every { urlFactory.create(any()) } returns url
-        every { url.openConnection() } returns conn
-        every { conn.contentType } returns "application/pdf"
-        every { conn.connect() } returns Unit
-
-        val result = OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "HEAD", urlFactory)
-
-        assertTrue(result)
-        verify { conn.connect() }
-        verify { conn.disconnect() }
+    fun `isPdf returns false when neither mimeType nor contentDisposition indicate pdf`() {
+        assertFalse(OSIABPdfHelper.isPdf("text/html", "inline"))
     }
 
     @Test
-    fun `returns true when disposition header contains pdf and content type is empty`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        val url = mockk<URL>()
-        val conn = mockk<HttpURLConnection>(relaxed = true)
-        every { urlFactory.create(any()) } returns url
-        every { url.openConnection() } returns conn
-        every { conn.contentType } returns null
-        every { conn.getHeaderField("Content-Disposition") } returns "attachment; filename=test.pdf"
-        every { conn.connect() } returns Unit
-
-        val result = OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "HEAD", urlFactory)
-
-        assertTrue(result)
-        verify { conn.connect() }
-        verify { conn.disconnect() }
+    fun `isPdf returns false when both are null`() {
+        assertFalse(OSIABPdfHelper.isPdf(null, null))
     }
 
-    @Test
-    fun `returns false when neither content type nor disposition indicate pdf`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        val url = mockk<URL>()
-        val conn = mockk<HttpURLConnection>(relaxed = true)
-        every { urlFactory.create(any()) } returns url
-        every { url.openConnection() } returns conn
-        every { conn.contentType } returns "text/html"
-        every { conn.getHeaderField("Content-Disposition") } returns "inline"
-        every { conn.connect() } returns Unit
+    // endregion
 
-        val result = OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "HEAD", urlFactory)
-
-        assertFalse(result)
-        verify { conn.connect() }
-        verify { conn.disconnect() }
-    }
-
-    @Test
-    fun `sets Range header for GET method`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        val url = mockk<URL>()
-        val conn = mockk<HttpURLConnection>(relaxed = true)
-        every { urlFactory.create(any()) } returns url
-        every { url.openConnection() } returns conn
-        every { conn.contentType } returns "application/pdf"
-        every { conn.connect() } returns Unit
-
-        OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "GET", urlFactory)
-
-        verify { conn.setRequestProperty("Range", "bytes=0-0") }
-        verify { conn.connect() }
-        verify { conn.disconnect() }
-    }
-
-    @Test
-    fun `returns false if connection is null`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        val url = mockk<URL>()
-        every { urlFactory.create(any()) } returns url
-        every { url.openConnection() } returns null
-
-        val result = OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "HEAD", urlFactory)
-
-        assertFalse(result)
-    }
-
-    @Test
-    fun `returns false if exception is thrown`() {
-        val urlFactory = mockk<OSIABPdfHelper.UrlFactory>()
-        every { urlFactory.create(any()) } throws RuntimeException("Network error")
-
-        val result = try {
-            OSIABPdfHelper.checkPdfByRequest("http://example.com/test.pdf", "HEAD", urlFactory)
-        } catch (_: Exception) {
-            false
-        }
-
-        assertFalse(result)
-    }
+    // region downloadPdfToCache
 
     @Test
     fun `downloadPdfToCache creates file with content`() {
@@ -205,4 +81,6 @@ class OSIABPdfHelperTest {
         file.delete()
         cacheDir.deleteRecursively()
     }
+
+    // endregion
 }


### PR DESCRIPTION
## Description

This PR moves logic for checking if a url is hosting a PDF from `handleLoadUrl` to [webview.setDownloadListener](https://developer.android.com/reference/android/webkit/DownloadListener). Instead of us explicitly checking the mime type by doing an HTTP request to the server before loading the url, we load the url and then wait for the webview to inform us if this is a file that can be downloaded, and then check if it's a PDF there.

This fixes an issue on ASPX and OutSystems Traditional Web Apps where multiple requests were triggering "Preparation" server action more than once when loading said web page in a WebView, even if the web page hosted no PDFs.

## Context

References:

References:
- https://outsystemsrd.atlassian.net/browse/RMET-5141
- https://outsystemsrd.atlassian.net/browse/RPM-6744
- https://success.outsystems.com/documentation/11/building_apps/application_logic/actions_in_web_applications/#preparation-actions
- Small slack thread on Traditional OutSystems Web Apps https://outsystems.slack.com/archives/C04ND35707P/p1776336737181489

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

To test that the issue is fixed, install and compare the two APKs (signatures may not match so you may need to uninstall one when uninstalling the other)

- Before: https://drive.google.com/file/d/1T0Powa4ZSZ3lQ96eUSKBpD-ldLcV6ykd/view?usp=sharing 
- After: https://drive.google.com/file/d/1SdExRuIStnDzSUC_XaPBDjL2mn8eYPyF/view?usp=sharing

In your computer access https://enmobile11-dev.outsystemsenterprise.com/ServiceCenter/General_Logs.aspx, and search for RMET-5141 Callback. Open the app and press "Button IAB WebView (bug)". After a second or two refresh the logs page, you'll see three logs for the old apk, and just 1 for the new apk.

To test general behavior with IAB after this change (including open PDFs), check the sample app:

- Before: https://drive.google.com/file/d/1cCz2kqmb2q4zhph8nq6-fsPZPwlGxM8M/view?usp=sharing
- After: https://drive.google.com/file/d/1lUW6ixYm3uRMHdqsCS5N970cekTBrSGP/view?usp=drive_link

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
