### PR TITLE
fix: explicitly grant URI permissions for photo/video capture intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1]
+
+### Fixes
+
+- Explicitly grant `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_WRITE_URI_PERMISSION` when launching the photo/video capture intents from the WebView file chooser, required for Android 18's implicit URI grant restriction ([RMET-5241](https://outsystemsrd.atlassian.net/browse/RMET-5241)).
+
 ## [2.0.0]
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -732,6 +732,7 @@ open class OSIABWebViewActivity : AppCompatActivity() {
                     }
                     val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
                         putExtra(MediaStore.EXTRA_OUTPUT, currentPhotoUri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                     }
                     intentList.add(takePictureIntent)
                 }
@@ -746,6 +747,7 @@ open class OSIABWebViewActivity : AppCompatActivity() {
                     }
                     val takeVideoIntent = Intent(MediaStore.ACTION_VIDEO_CAPTURE).apply {
                         putExtra(MediaStore.EXTRA_OUTPUT, currentVideoUri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                     }
                     intentList.add(takeVideoIntent)
                 }


### PR DESCRIPTION
## Description
The WebView file chooser's `takePictureIntent` (`ACTION_IMAGE_CAPTURE`) and `takeVideoIntent` (`ACTION_VIDEO_CAPTURE`) sent no URI grant flags at all for their FileProvider output URIs. Added `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_WRITE_URI_PERMISSION` to both. Also bumped the library version to 2.0.1.

## Context
Android 18 removes automatic URI permission grants for `ACTION_IMAGE_CAPTURE` intents (and similarly affects `ACTION_VIDEO_CAPTURE`) — apps must now explicitly request read/write access, or the camera app silently fails to write the captured media back into the URI.

More info: https://developer.android.com/about/versions/17/behavior-changes-all#restrict-implicit-uri-grants

[RMET-5241](https://outsystemsrd.atlassian.net/browse/RMET-5241)

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Manual: exercised the WebView file chooser's photo capture and video record flows via the `capacitor-os-inappbrowser` plugin's `openInWebView`, built locally against this branch. Confirmed both work on Android 8 (this library's minSdk) and Android 17.

## Screenshots (if appropriate)
N/A

## Checklist
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

[RMET-5241]: https://outsystemsrd.atlassian.net/browse/RMET-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ