### PR TITLE
fix: send BrowserFinished from onDestroy so closing while backgrounded still notifies the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2]
+
+### Fixes
+
+- Send the `BrowserFinished` event from `onDestroy`, so it is no longer lost when the WebView is closed while the app is in the background. Previously the event was only sent from `onStop`, which Android skips when `finish()` is called on an already stopped activity, leaving the browser closed without notifying the app and blocking any new browser from opening until app restart ([RMET-5394](https://outsystemsrd.atlassian.net/browse/RMET-5394)).
+
 ## [2.0.1]
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ioninappbrowser-android</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </project>

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -979,7 +979,6 @@ open class OSIABWebViewActivity : AppCompatActivity() {
     }
 
     /** Responsible for sending events to the main process.
-     * Must not go through lifecycleScope, which is already cancelled during onDestroy.
      * @param event object to broadcast to the event bus
      */
     private fun sendWebViewEvent(event: OSIABEvents) {

--- a/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
+++ b/src/main/java/com.outsystems.plugins.inappbrowser/osinappbrowserlib/views/OSIABWebViewActivity.kt
@@ -267,14 +267,11 @@ open class OSIABWebViewActivity : AppCompatActivity() {
         }
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onDestroy() {
+        // sent here instead of onStop, which is skipped when finish() happens on an already stopped activity
         if (isFinishing) {
             sendWebViewEvent(OSIABEvents.BrowserFinished(browserId))
         }
-    }
-
-    override fun onDestroy() {
         closeReceiver?.let {
             try {
                 unregisterReceiver(it)
@@ -981,13 +978,12 @@ open class OSIABWebViewActivity : AppCompatActivity() {
         }
     }
 
-    /** Responsible for sending events using Kotlin Flows.
+    /** Responsible for sending events to the main process.
+     * Must not go through lifecycleScope, which is already cancelled during onDestroy.
      * @param event object to broadcast to the event bus
      */
     private fun sendWebViewEvent(event: OSIABEvents) {
-        lifecycleScope.launch {
-            OSIABEvents.broadcastEvent(this@OSIABWebViewActivity, event)
-        }
+        OSIABEvents.broadcastEvent(this, event)
     }
 
     private fun showErrorScreen() {


### PR DESCRIPTION
## Description
When the WebView is closed while the app is in the background, the activity is already stopped, so finish() goes straight to onDestroy and onStop never runs again. The event was never sent, the app never got browserClosed, the close callback never resolved, and every later open waited on that close forever. Only an app restart recovered.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-5394

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Tested on Pixel 8 Pro with [repro app](https://enmobile11-dev.outsystemsenterprise.com/NativeAppBuilder/App?AppKey=0d936c35-1bdc-497f-aa96-d1d382576aec)

